### PR TITLE
Uses ajaxSuccess to restart timers after any ajax request

### DIFF
--- a/jquery.sessionTimeout.1.0.js
+++ b/jquery.sessionTimeout.1.0.js
@@ -44,7 +44,7 @@
 //     Default: 1200000 (20 minutes)
 //
 (function( $ ){
-  $("document").ajaxStop(function(){
+  $("document").ajaxSuccess(function(){
     // Stop redirect timer and restart warning timer
     controlRedirTimer('stop');
     controlDialogTimer('start');


### PR DESCRIPTION
Resolves #2 using jQuery.ajaxSuccess() to reset the timers after any ajax request.
